### PR TITLE
chore: use imported openai key

### DIFF
--- a/src/routes/api/generate/+server.ts
+++ b/src/routes/api/generate/+server.ts
@@ -7,7 +7,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 
 // Create an OpenAI API client (that's edge friendly!)
 const openai = new OpenAI({
-	apiKey: process.env.OPENAI_API_KEY || ''
+	apiKey: OPENAI_API_KEY || ''
 });
 
 // IMPORTANT! Set the runtime to edge: https://vercel.com/docs/functions/edge-functions/edge-runtime


### PR DESCRIPTION
This PR removes the usage of `OPENAI_API_KEY` from `process.env` and replaces it with the imported `OPENAI_API_KEY` from `$env/static/private`